### PR TITLE
bugfix overflow send pdu data

### DIFF
--- a/src/S7CommPlusDriver/S7CommPlusConnection.cs
+++ b/src/S7CommPlusDriver/S7CommPlusConnection.cs
@@ -173,7 +173,6 @@ namespace S7CommPlusDriver
             int sourcePos = 0;
             int sendLen;
             int NegotiatedIsoPduSize = 1024;// TODO: Respect the negotiated TPDU size
-            byte[] packet = new byte[NegotiatedIsoPduSize];
 
             // 4 Byte TPKT Header
             // 3 Byte ISO-Header
@@ -181,6 +180,7 @@ namespace S7CommPlusDriver
             // 4 Byte S7CommPlus Header
             // 4 Byte S7CommPlus Trailer (must fit into last PDU)
             int MaxSize = NegotiatedIsoPduSize - 4 - 3 - 5 - 17 - 4 - 4;
+            byte[] packet = new byte[MaxSize + 4]; //max packet size is always MaxSize + PDU Header
 
             while (bytesToSend > 0)
             {
@@ -207,6 +207,7 @@ namespace S7CommPlusDriver
                 // Trailer only in last packet
                 if (bytesToSend == 0)
                 {
+                    Array.Resize(ref packet, sendLen + 4); //resize only the last package to sendLen + TrailerLen
                     packet[sendLen] = 0x72;
                     sendLen++;
                     packet[sendLen] = protoVersion;
@@ -216,7 +217,6 @@ namespace S7CommPlusDriver
                     packet[sendLen] = 0;
                     sendLen++;
                 }
-                Array.Resize(ref packet, sendLen);
                 m_client.Send(packet);
             }
             return m_LastError;


### PR DESCRIPTION
Hi Thomas,

zuerst einmal vielen Dank für dieses tolle Projekt und die ganze Arbeit die du schon hier reingesteckt hast, echt klasse!

Habe beim rumprobieren einen kleinen Bug gefunden. Und zwar kann es passieren, dass wenn das letzte Packet was gesendet wird zufällig grade noch unter der `MaxSize + 4` Größe liegt, eine Zugriffsverletzung auftritt. 

Da das Array im vorherigen Schleifendruchlauf auf die Maximal länge geresized wurde, beim letzten Packet aber noch die 4 Bytes für den Trailer benötigt werden, reicht der Platz im Array nicht mehr aus.

Ich habe es nun so geändert, dass als default Größe für das Array `MaxSize + 4` genommen wird und nur beim letzten Packet ein resize stattfindet.

Wenn du Fragen hast lass es mich wissen.
Tim
